### PR TITLE
fix: correct readings for like... every 羽 amount

### DIFF
--- a/data/counters.ts
+++ b/data/counters.ts
@@ -1707,7 +1707,43 @@ export const COUNTER_缶: Counter = {
 };
 
 export const COUNTER_羽: Counter = {
-  annotations: {},
+  annotations: {
+    4: [
+      {
+        frequency: CounterReadingFrequency.Uncommon,
+        kind: "frequency",
+        reading: "よわ",
+      },
+    ],
+    6: [
+      {
+        frequency: CounterReadingFrequency.Uncommon,
+        kind: "frequency",
+        reading: "ろっぱ",
+      },
+    ],
+    7: [
+      {
+        frequency: CounterReadingFrequency.Uncommon,
+        kind: "frequency",
+        reading: "しちわ",
+      },
+    ],
+    8: [
+      {
+        frequency: CounterReadingFrequency.Uncommon,
+        kind: "frequency",
+        reading: "はっぱ",
+      },
+    ],
+    10: [
+      {
+        frequency: CounterReadingFrequency.Uncommon,
+        kind: "frequency",
+        reading: "じっぱ",
+      },
+    ],
+  },
   counterId: "羽",
   disambiguations: [],
   englishName: "birds and rabbits",

--- a/sql/counter_reading_frequency.sql
+++ b/sql/counter_reading_frequency.sql
@@ -10,4 +10,19 @@ CREATE TABLE counter_reading_frequency (
 INSERT INTO
   "counter_reading_frequency" (counter_id, amount, kana, frequency)
 VALUES('日', 20, 'にじゅうにち', 'uncommon');
+INSERT INTO
+  "counter_reading_frequency" (counter_id, amount, kana, frequency)
+VALUES('羽', 7, 'しちわ', 'uncommon');
+INSERT INTO
+  "counter_reading_frequency" (counter_id, amount, kana, frequency)
+VALUES('羽', 4, 'よわ', 'uncommon');
+INSERT INTO
+  "counter_reading_frequency" (counter_id, amount, kana, frequency)
+VALUES('羽', 6, 'ろっぱ', 'uncommon');
+INSERT INTO
+  "counter_reading_frequency" (counter_id, amount, kana, frequency)
+VALUES('羽', 8, 'はっぱ', 'uncommon');
+INSERT INTO
+  "counter_reading_frequency" (counter_id, amount, kana, frequency)
+VALUES('羽', 10, 'じっぱ', 'uncommon');
 COMMIT;

--- a/src/japanese/counters.ts
+++ b/src/japanese/counters.ts
@@ -239,7 +239,7 @@ function conjugateRegularKangoReading(
         case "solo": {
           switch (amountBreakdown.solo) {
             case 3: {
-              counterChanges = [COUNTER_BA_GYOU];
+              counterChanges = [{}, COUNTER_BA_GYOU];
               break;
             }
             case 4: {

--- a/src/japanese/counters.ts
+++ b/src/japanese/counters.ts
@@ -229,6 +229,11 @@ function conjugateRegularKangoReading(
       numberChanges = KANGO_COUNTER_W_CHANGES;
 
       switch (amountBreakdown.lowestUnit) {
+        case "man":
+        case "sen": {
+          counterChanges = [{}, COUNTER_BA_GYOU];
+          break;
+        }
         case "jyuu": {
           counterChanges = [
             { tag: "counter-wa-10-full-num" },

--- a/src/japanese/counters.ts
+++ b/src/japanese/counters.ts
@@ -113,7 +113,17 @@ const KANGO_COUNTER_W_CHANGES: FinalNumberChanges = {
       },
     ],
   ],
-  [JYUU]: [[{ type: "replace", kana: "じっ", kanji: "十" }]],
+  [JYUU]: [
+    [
+      { type: "trailing-small-tsu" },
+      { type: "tag", tag: "counter-wa-10-small-tsu" },
+    ],
+    [
+      { type: "replace", kana: "じっ", kanji: "十" },
+      { type: "tag", tag: "counter-wa-10-small-tsu" },
+    ],
+    [{ type: "preserve" }, { type: "tag", tag: "counter-wa-10-full-num" }],
+  ],
 };
 /* eslint-enable sort-keys */
 
@@ -220,7 +230,10 @@ function conjugateRegularKangoReading(
 
       switch (amountBreakdown.lowestUnit) {
         case "jyuu": {
-          counterChanges = [COUNTER_PA_GYOU];
+          counterChanges = [
+            { tag: "counter-wa-10-full-num" },
+            { gyou: "pa", tag: "counter-wa-10-small-tsu" },
+          ];
           break;
         }
         case "solo": {

--- a/src/japanese/counters.ts
+++ b/src/japanese/counters.ts
@@ -116,13 +116,20 @@ const KANGO_COUNTER_W_CHANGES: FinalNumberChanges = {
   [JYUU]: [
     [
       { type: "trailing-small-tsu" },
-      { type: "tag", tag: "counter-wa-10-small-tsu" },
+      { type: "tag", tag: "counter-wa-10-100-small-tsu" },
     ],
     [
       { type: "replace", kana: "じっ", kanji: "十" },
-      { type: "tag", tag: "counter-wa-10-small-tsu" },
+      { type: "tag", tag: "counter-wa-10-100-small-tsu" },
     ],
-    [{ type: "preserve" }, { type: "tag", tag: "counter-wa-10-full-num" }],
+    [{ type: "preserve" }, { type: "tag", tag: "counter-wa-10-100-full-num" }],
+  ],
+  [HYAKU]: [
+    [
+      { type: "trailing-small-tsu" },
+      { type: "tag", tag: "counter-wa-10-100-small-tsu" },
+    ],
+    [{ type: "preserve" }, { type: "tag", tag: "counter-wa-10-100-full-num" }],
   ],
 };
 /* eslint-enable sort-keys */
@@ -234,10 +241,11 @@ function conjugateRegularKangoReading(
           counterChanges = [{}, COUNTER_BA_GYOU];
           break;
         }
-        case "jyuu": {
+        case "jyuu":
+        case "hyaku": {
           counterChanges = [
-            { tag: "counter-wa-10-full-num" },
-            { gyou: "pa", tag: "counter-wa-10-small-tsu" },
+            { tag: "counter-wa-10-100-full-num" },
+            { gyou: "pa", tag: "counter-wa-10-100-small-tsu" },
           ];
           break;
         }

--- a/src/japanese/tags.ts
+++ b/src/japanese/tags.ts
@@ -7,8 +7,8 @@ export type Tag =
   | "counter-wa-6-8-pa"
   | "counter-wa-6-8-small-tsu"
   | "counter-wa-6-8-wa"
-  | "counter-wa-10-full-num"
-  | "counter-wa-10-small-tsu"
+  | "counter-wa-10-100-full-num"
+  | "counter-wa-10-100-small-tsu"
   | "strange";
 
 const TAG_INCOMPATIBILITIES: { [tag in Tag]: ReadonlySet<Tag> } = {
@@ -18,8 +18,8 @@ const TAG_INCOMPATIBILITIES: { [tag in Tag]: ReadonlySet<Tag> } = {
   "counter-wa-6-8-pa": new Set<Tag>(["counter-wa-6-8-full-num"]),
   "counter-wa-6-8-small-tsu": new Set<Tag>(["counter-wa-6-8-wa"]),
   "counter-wa-6-8-wa": new Set<Tag>(["counter-wa-6-8-small-tsu"]),
-  "counter-wa-10-full-num": new Set<Tag>(["counter-wa-10-small-tsu"]),
-  "counter-wa-10-small-tsu": new Set<Tag>(["counter-wa-10-full-num"]),
+  "counter-wa-10-100-full-num": new Set<Tag>(["counter-wa-10-100-small-tsu"]),
+  "counter-wa-10-100-small-tsu": new Set<Tag>(["counter-wa-10-100-full-num"]),
   hyaku: new Set<Tag>(["ippyaku"]),
   ippyaku: new Set<Tag>(["hyaku"]),
   strange: new Set<Tag>(),

--- a/src/japanese/tags.ts
+++ b/src/japanese/tags.ts
@@ -7,6 +7,8 @@ export type Tag =
   | "counter-wa-6-8-pa"
   | "counter-wa-6-8-small-tsu"
   | "counter-wa-6-8-wa"
+  | "counter-wa-10-full-num"
+  | "counter-wa-10-small-tsu"
   | "strange";
 
 const TAG_INCOMPATIBILITIES: { [tag in Tag]: ReadonlySet<Tag> } = {
@@ -16,6 +18,8 @@ const TAG_INCOMPATIBILITIES: { [tag in Tag]: ReadonlySet<Tag> } = {
   "counter-wa-6-8-pa": new Set<Tag>(["counter-wa-6-8-full-num"]),
   "counter-wa-6-8-small-tsu": new Set<Tag>(["counter-wa-6-8-wa"]),
   "counter-wa-6-8-wa": new Set<Tag>(["counter-wa-6-8-small-tsu"]),
+  "counter-wa-10-full-num": new Set<Tag>(["counter-wa-10-small-tsu"]),
+  "counter-wa-10-small-tsu": new Set<Tag>(["counter-wa-10-full-num"]),
   hyaku: new Set<Tag>(["ippyaku"]),
   ippyaku: new Set<Tag>(["hyaku"]),
   strange: new Set<Tag>(),


### PR DESCRIPTION
The bug report in #61 was that 10羽 didn't have enough readings. While comparing it to [Tofugu's list](https://www.tofugu.com/japanese/japanese-counter-wa/), I realized that like... every cell for 〜羽 was wrong in some way.

Some of this was that I needed to use the counter frequency stuff added in #63, so I've done that.

But I also consulted the [systematic reading chart](https://www.tofugu.com/japanese/japanese-counters-guide/) and I was missing a whole bunch of numbers for わ行.

This PR methodically goes through the counters for わ and ensures we've got all of the readings, marked with their correct frequencies.